### PR TITLE
Hkatz/vpa deployment exclusion and updates (#140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,35 @@ You can set the default behavior for VPA creation using some flags. When specifi
 * `--include-namespaces` - create VPAs in these namespaces, in addition to any that are labeled
 * `--exclude-namespaces` - when `--on-by-default` is set, exclude this comma-separated list of namespaces
 
+#### Enable Namespaces
+
+Namespaces are considered enabled or managed by goldilocks when the Namespace
+has the enabled label set to "true", for example:
+
+```
+kubectl label ns goldilocks goldilocks.fairwinds.com/enabled=true
+```
+
+#### VPA Update Mode
+
+> Note: This feature is for advanced usage only and is not recommended nor the default!
+
+VPAs created for Deployments in a Namespace have an update mode of "off" by
+default, meaning the VPAs only report recommendations and do not actually
+auto-scale the Pods.
+
+The update mode can be changed for a namespace by labels as well, for example:
+
+```
+kubectl label ns goldilocks goldilocks.fairwinds.com/vpa-update-mode="auto"
+```
+
+#### Deployment Specifications
+
+If you want a specific Deployment to have a VPA in a specific update mode,
+then you can annotate the Deployment with `goldilocks.fairwinds.com/vpa-update-mode=<mode>`
+to control the update mode for a specific Deployment in a Namespace (regardless of labeling on the Namespace).
+
 ### create-vpas
 
 `goldilocks create-vpas -n some-namespace`

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -49,6 +49,8 @@ var controllerCmd = &cobra.Command{
 		vpaReconciler.IncludeNamespaces = includeNamespaces
 		vpaReconciler.ExcludeNamespaces = excludeNamespaces
 
+		klog.V(4).Infof("Starting controller with Reconciler: %+v", vpaReconciler)
+
 		// create a channel for sending a stop to kube watcher threads
 		stop := make(chan bool, 1)
 		defer close(stop)

--- a/pkg/vpa/test_constants.go
+++ b/pkg/vpa/test_constants.go
@@ -48,6 +48,16 @@ var nsNotLabeled = &corev1.Namespace{
 	},
 }
 
+var nsEnabledUpdateModeAuto = &corev1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "labeled-true",
+		Labels: map[string]string{
+			"goldilocks.fairwinds.com/enabled":         "True",
+			"goldilocks.fairwinds.com/vpa-update-mode": "auto",
+		},
+	},
+}
+
 // A VPA Object that can be used to verify tests
 var updateMode = v1beta2.UpdateModeOff
 var testVPA = &v1beta2.VerticalPodAutoscaler{
@@ -72,5 +82,14 @@ var testVPA = &v1beta2.VerticalPodAutoscaler{
 var testDeployment = &appsv1.Deployment{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "test-deploy",
+	},
+}
+
+var testDeploymentExcluded = &appsv1.Deployment{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "test-deploy",
+		Annotations: map[string]string{
+			"goldilocks.fairwinds.com/vpa-update-mode": "off",
+		},
 	},
 }

--- a/pkg/vpa/vpa_test.go
+++ b/pkg/vpa/vpa_test.go
@@ -87,15 +87,22 @@ func Test_listVPA(t *testing.T) {
 	_ = rec.createVPA("ns", "test2", updateMode)
 	_ = rec.createVPA("ns2", "test3", updateMode)
 
-	vpaList1 := rec.listVPAs("ns")
-	assert.EqualValues(t, vpaList1, []string{"test1", "test2"})
+	vpaList1, err := rec.listVPAs("ns")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, vpaList1)
+	assert.EqualValues(t, vpaList1[0].Name, "test1")
+	assert.EqualValues(t, vpaList1[1].Name, "test2")
 
-	vpaList2 := rec.listVPAs("")
-	assert.EqualValues(t, vpaList2, []string{"test1", "test2", "test3"})
+	vpaList2, err := rec.listVPAs("")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, vpaList2)
+	assert.EqualValues(t, vpaList2[0].Name, "test1")
+	assert.EqualValues(t, vpaList2[1].Name, "test2")
+	assert.EqualValues(t, vpaList2[2].Name, "test3")
 
-	var expected []string
-	vpaList3 := rec.listVPAs("nonexistent")
-	assert.EqualValues(t, vpaList3, expected)
+	vpaList3, err := rec.listVPAs("nonexistent")
+	assert.NoError(t, err)
+	assert.Empty(t, vpaList3)
 }
 
 func Test_namespaceIsManaged(t *testing.T) {
@@ -331,4 +338,71 @@ func Test_ReconcileNamespaceRemoveLabel(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(vpaList.Items))
 	assert.EqualValues(t, vpaList, &v1beta2.VerticalPodAutoscalerList{})
+}
+
+func Test_ReconcileNamespace_ExcludeDeploymentAnnotation(t *testing.T) {
+	setupVPAForTests()
+	VPAClient := GetInstance().VPAClient
+	KubeClient := GetInstance().KubeClient
+
+	// Create a properly labeled namespace
+	_, err := KubeClient.Client.CoreV1().Namespaces().Create(nsEnabledUpdateModeAuto)
+	assert.NoError(t, err)
+	nsName := nsLabeledTrue.ObjectMeta.Name
+
+	// Create an excluded deployment in the namespace and reconcile
+	_, err = KubeClient.Client.AppsV1().Deployments(nsName).Create(testDeploymentExcluded)
+	assert.NoError(t, err)
+	err = GetInstance().ReconcileNamespace(nsLabeledTrue)
+	assert.NoError(t, err)
+
+	// There should be one vpa object with UpdateModeOff
+	vpaList, err := VPAClient.Client.AutoscalingV1beta2().VerticalPodAutoscalers(nsName).List(metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(vpaList.Items))
+	assert.EqualValues(t, *vpaList.Items[0].Spec.UpdatePolicy.UpdateMode, v1beta2.UpdateModeOff)
+}
+
+func Test_ReconcileNamespace_ChangeUpdateMode(t *testing.T) {
+	setupVPAForTests()
+	VPAClient := GetInstance().VPAClient
+	KubeClient := GetInstance().KubeClient
+
+	// Create a properly labeled namespace
+	_, err := KubeClient.Client.CoreV1().Namespaces().Create(nsLabeledTrue)
+	assert.NoError(t, err)
+	nsName := nsLabeledTrue.ObjectMeta.Name
+
+	// Create a deployment in the namespace and reconcile
+	_, err = KubeClient.Client.AppsV1().Deployments(nsName).Create(testDeployment)
+	assert.NoError(t, err)
+	err = GetInstance().ReconcileNamespace(nsLabeledTrue)
+	assert.NoError(t, err)
+
+	// There should be one vpa object with updatemode "off"
+	vpaList, err := VPAClient.Client.AutoscalingV1beta2().VerticalPodAutoscalers(nsName).List(metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(vpaList.Items))
+	assert.EqualValues(t, *vpaList.Items[0].Spec.UpdatePolicy.UpdateMode, v1beta2.UpdateModeOff)
+
+	// Update the namespace labels to be be vpa-update-mode=auto and reconcile
+	updatedNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsName,
+			Labels: map[string]string{
+				"goldilocks.fairwinds.com/enabled":         "true",
+				"goldilocks.fairwinds.com/vpa-update-mode": "auto",
+			},
+		},
+	}
+	_, err = KubeClient.Client.CoreV1().Namespaces().Update(updatedNS)
+	assert.NoError(t, err)
+	err = GetInstance().ReconcileNamespace(updatedNS)
+	assert.NoError(t, err)
+
+	// There should be one vpa object with updatemode "auto"
+	vpaList1, err := VPAClient.Client.AutoscalingV1beta2().VerticalPodAutoscalers(nsName).List(metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(vpaList1.Items))
+	assert.EqualValues(t, *vpaList1.Items[0].Spec.UpdatePolicy.UpdateMode, v1beta2.UpdateModeAuto)
 }


### PR DESCRIPTION
* Revert "Make units consistent for memory fixes issue #78 (#103)"

This reverts commit e55026dd67d00b3c9f68946216ac9df09c6d4a9a.

* Add FormatResourceList and test cases

* Use v1 resource memory constants instead of hardcoded strings

* Add a VPAUpdateMode to the vpa.Reconciler

The VPAUpdateMode field will allow us to use Goldilocks to create VPAs
that operate outside of "off" mode.

* Add ability to specify vpa update mode

This commit adds a parameter to createVPA that allows the user to
specify the update mode for the VPA. The mechanism for specifying this
is the label goldilocks.fairwinds.com/vpaUpdateMode.

* Extract variables instead of hardcoded values

* VPA update mode label case insensitive

Kubernetes labels are based on DNS names, which are case insensitive.
However, the current label used to specify the update mode of created
VPAs, vpaUpdateMode, is case sensitive. This has caused a bug that
results in all VPAs being created in "Off" mode. This commit fixes that
bug by using a case-insensitive label to specify the vpa-update-mode.

* Summary fix for multiple containers in a pod (#123)

* go.mod updated for some reason

* Add support for all VPA UpdateModes

* Use ParseBool for deployment enabled label value

* Use ParseBool for namespace enabled label value

* Use lowercase for switch statement

* Add Deployment Exclusion Annotation

Also:
 - Update reconciler to use VPA and Deployment objects
   directly (instead of names)
 - Update reconciler logging
 - Update/Add vpa tests

* Change no-vpa annotation to vpa-opt-out (to opt out of vpa in auto mode)

Also:
 - Update vpa tests
 - Fix vpa-opt-out logic

* Add more logging to VPA reconciler

* Fix namespace logs to use Name instead of the full Namespace

* Update README

* Fix Typo aut -> auto

Co-Authored-By: Andrew Suderman <andrew@sudermanjr.com>

* Fix grammar matched -> match

Co-Authored-By: Andrew Suderman <andrew@sudermanjr.com>

* Use vpa-update-mode as an annotation for Deployment specific VPA control

* Fix ineffectual assignment

* Fix test label

* Use index to get correct vpa

* Use short-hand if statement for map lookup

Co-authored-by: John Turner <jturner@squarespace.com>
Co-authored-by: David Noyes <david.noyes@skybettingandgaming.com>
Co-authored-by: Andrew Suderman <andrew@sudermanjr.com>