### PR TITLE
Hkatz/batch summary deployments api call (#194)

### DIFF
--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -17,6 +17,7 @@ package summary
 import (
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -64,6 +65,9 @@ type Summarizer struct {
 
 	// cached list of vpas
 	vpas []v1beta2.VerticalPodAutoscaler
+
+	// cached map of deploy/vpa name -> deployment
+	deploymentForVPANamed map[string]*appsv1.Deployment
 }
 
 // NewSummarizer returns a Summarizer for all goldilocks managed VPAs in all Namespaces
@@ -93,14 +97,15 @@ func (s Summarizer) GetSummary() (Summary, error) {
 	summary := Summary{
 		Namespaces: map[string]namespaceSummary{},
 	}
-	// cached vpas
-	if s.vpas == nil {
-		err := s.UpdateVPAs()
+	// cached vpas and deployments
+	if s.vpas == nil || s.deploymentForVPANamed == nil {
+		err := s.Update()
 		if err != nil {
 			return summary, err
 		}
 	}
 
+	// nothing to summarize
 	if len(s.vpas) <= 0 {
 		return summary, nil
 	}
@@ -127,10 +132,10 @@ func (s Summarizer) GetSummary() (Summary, error) {
 			Containers:     map[string]containerSummary{},
 		}
 
-		// find all deployments in the namespace for this VPA
-		deployment, err := s.kubeClient.Client.AppsV1().Deployments(namespace).Get(dSummary.DeploymentName, metav1.GetOptions{})
-		if err != nil {
-			klog.Errorf("Error retrieving deployment from API: %v", err)
+		deployment, ok := s.deploymentForVPANamed[vpa.Name]
+		if !ok {
+			klog.Errorf("no matching Deployment found for VPA/%s", vpa.Name)
+			continue
 		}
 
 		if vpa.Status.Recommendation == nil {
@@ -183,16 +188,31 @@ func (s Summarizer) GetSummary() (Summary, error) {
 	return summary, nil
 }
 
-// UpdateVPAs updates the list of VPAs that the summarizer uses
-func (s *Summarizer) UpdateVPAs() error {
+// Update the set of VPAs and Deployments that the Summarizer uses for creating a summary
+func (s *Summarizer) Update() error {
+	err := s.updateVPAs()
+	if err != nil {
+		klog.Error(err.Error())
+		return err
+	}
+
+	err = s.updateDeployments()
+	if err != nil {
+		klog.Error(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func (s *Summarizer) updateVPAs() error {
 	nsLog := s.namespace
 	if s.namespace == namespaceAllNamespaces {
 		nsLog = "all namespaces"
 	}
 	klog.V(3).Infof("Looking for VPAs in %s with labels: %v", nsLog, s.vpaLabels)
-	vpas, err := s.listVPAs()
+	vpas, err := s.listVPAs(getVPAListOptionsForLabels(s.vpaLabels))
 	if err != nil {
-		klog.Error(err.Error())
 		return err
 	}
 	klog.V(10).Infof("Found vpas: %v", vpas)
@@ -201,10 +221,8 @@ func (s *Summarizer) UpdateVPAs() error {
 	return nil
 }
 
-// Run creates a summary of the vpa info for all namespaces.
-func (s Summarizer) listVPAs() ([]v1beta2.VerticalPodAutoscaler, error) {
-	vpaListOptions := getVPAListOptionsForLabels(s.vpaLabels)
-	vpas, err := s.vpaClient.Client.AutoscalingV1beta2().VerticalPodAutoscalers(s.namespace).List(vpaListOptions)
+func (s Summarizer) listVPAs(listOptions metav1.ListOptions) ([]v1beta2.VerticalPodAutoscaler, error) {
+	vpas, err := s.vpaClient.Client.AutoscalingV1beta2().VerticalPodAutoscalers(s.namespace).List(listOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -216,4 +234,35 @@ func getVPAListOptionsForLabels(vpaLabels map[string]string) metav1.ListOptions 
 	return metav1.ListOptions{
 		LabelSelector: labels.Set(vpaLabels).String(),
 	}
+}
+
+func (s *Summarizer) updateDeployments() error {
+	nsLog := s.namespace
+	if s.namespace == namespaceAllNamespaces {
+		nsLog = "all namespaces"
+	}
+	klog.V(3).Infof("Looking for Deployments in %s", nsLog)
+	deployments, err := s.listDeployments(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	klog.V(10).Infof("Found deployments: %v", deployments)
+
+	// map the deployment.name -> &deployment for easy vpa lookup (since vpa.Name == deployment.Name for matching vpas/deployments)
+	s.deploymentForVPANamed = map[string]*appsv1.Deployment{}
+	for _, d := range deployments {
+		d := d
+		s.deploymentForVPANamed[d.Name] = &d
+	}
+
+	return nil
+}
+
+func (s Summarizer) listDeployments(listOptions metav1.ListOptions) ([]appsv1.Deployment, error) {
+	deployments, err := s.kubeClient.Client.AppsV1().Deployments(s.namespace).List(listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return deployments.Items, nil
 }


### PR DESCRIPTION
* Revert "Make units consistent for memory fixes issue #78 (#103)"

This reverts commit e55026dd67d00b3c9f68946216ac9df09c6d4a9a.

* Add FormatResourceList and test cases

* Use v1 resource memory constants instead of hardcoded strings

* Add a VPAUpdateMode to the vpa.Reconciler

The VPAUpdateMode field will allow us to use Goldilocks to create VPAs
that operate outside of "off" mode.

* Add ability to specify vpa update mode

This commit adds a parameter to createVPA that allows the user to
specify the update mode for the VPA. The mechanism for specifying this
is the label goldilocks.fairwinds.com/vpaUpdateMode.

* Extract variables instead of hardcoded values

* VPA update mode label case insensitive

Kubernetes labels are based on DNS names, which are case insensitive.
However, the current label used to specify the update mode of created
VPAs, vpaUpdateMode, is case sensitive. This has caused a bug that
results in all VPAs being created in "Off" mode. This commit fixes that
bug by using a case-insensitive label to specify the vpa-update-mode.

* Summary fix for multiple containers in a pod (#123)

* go.mod updated for some reason

* Add support for all VPA UpdateModes

* Use ParseBool for deployment enabled label value

* Use ParseBool for namespace enabled label value

* Use lowercase for switch statement

* Add Deployment Exclusion Annotation

Also:
 - Update reconciler to use VPA and Deployment objects
   directly (instead of names)
 - Update reconciler logging
 - Update/Add vpa tests

* Change no-vpa annotation to vpa-opt-out (to opt out of vpa in auto mode)

Also:
 - Update vpa tests
 - Fix vpa-opt-out logic

* Add more logging to VPA reconciler

* Fix namespace logs to use Name instead of the full Namespace

* Update README

* Fix Typo aut -> auto

Co-Authored-By: Andrew Suderman <andrew@sudermanjr.com>

* Fix grammar matched -> match

Co-Authored-By: Andrew Suderman <andrew@sudermanjr.com>

* Use vpa-update-mode as an annotation for Deployment specific VPA control

* Fix ineffectual assignment

* Fix test label

* Use index to get correct vpa

* Use short-hand if statement for map lookup

* Split templates by kind

* Restructure/Organize pkg/dashboard into sub-packages

* Add options pattern to pkg/dashboard

* Move handlers pkg back to dashboard ; Move dashboard.go -> router.go

* Change Summary format to better represent its logical data structure

* Change templates to work with new Summary structure

* Fix container resource recommendation formatting

* Move pkg/dashboard -> pkg/web

* Split templates and dashboard into files ; Make template util functions more flexible for the router and for new webpages

* Add /namespaces ; Make /namespaces the default route ; Style /namespaces ; Fix /dashboard

* Limit namespace-list.go data passed to template

* Fix dashboard link

* Add length to All Namespaces

* Fix summary_test.go

* Fix typo 'reccomendations' -> 'recommendations'

* Fix typo 'NamespceList' -> 'NamespaceList'

* Add clarifying comment about template data limiting

* Add outer structure to Summary

* Rename dashboard -> web

* Allow goldilocks' web RBAC to list/get namespaces

* Move common labels to utils.go

* Use correct labels location

* Attempt to fix e2e

* Fix incorrect args usage for namespace

* Add oidc auth support

* Remove redundant return statement from health.go

* Update cmd/web.go

Co-authored-by: Harrison Katz <hkatz@squarespace.com>

* Rename web back to -> dashboard

* Batch Summary Deployments list into a single API call ; Improves speed _significantly_

* Remove superfluous Error prefix in error message

Co-authored-by: Andrew Suderman <andrew@sudermanjr.com>

Co-authored-by: John Turner <jturner@squarespace.com>
Co-authored-by: David Noyes <david.noyes@skybettingandgaming.com>
Co-authored-by: Andrew Suderman <andrew@sudermanjr.com>